### PR TITLE
Add support for PDM 2.7.x to PDM 2.10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,7 +69,6 @@ steps:
           - "pdm25"
           - "pdm26"
           - "pdm27"
-          - "pdm28"
           - "pdm29"
           - "pdm210"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ small: &small
       resources-limit-memory: 20Gi
 
 env:
-  PDM_COMMAND: pdm27
+  PDM_COMMAND: pdm210
   PYTHON_VERSION: '3.9'
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 plugin_base: &plugin_base
     service-account-name: monorepo-ci
-    image: gcr.io/embark-shared/ml/ci-runner@sha256:54904440250d9ae14f6ddf6d72c577f2e06c85f79aa6ebe31558c35cbb93280f
+    image: gcr.io/embark-shared/ml/ci-runner@sha256:dac3595ade7e3e92ed006f6c29f461b71bb3a6b0ade8d3afb88ba8e55b9601d6
     default-secret-name: buildkite-k8s-plugin
     always-pull: false
     use-agent-node-affinity: true
@@ -70,6 +70,9 @@ steps:
           - "pdm26"
           - "pdm27"
           - "pdm28"
+          - "pdm29"
+          - "pdm210"
+
         command: bash .buildkite/run-pytest.sh {{matrix}}
         << : *small
 

--- a/pdm-plugin-torch/pdm_plugin_torch/config.py
+++ b/pdm-plugin-torch/pdm_plugin_torch/config.py
@@ -40,6 +40,6 @@ class Configuration:
                 )
 
         if self.enable_cpu:
-            resolves["cpu"] = ("https://download.pytorch.org/whl/cpu", "")
+            resolves["cpu"] = ("https://download.pytorch.org/whl/cpu", "+cpu")
 
         return resolves

--- a/pdm-plugin-torch/pdm_plugin_torch/main.py
+++ b/pdm-plugin-torch/pdm_plugin_torch/main.py
@@ -27,6 +27,7 @@ from pdm_plugin_torch.config import Configuration
 
 
 is_pdm210 = PySpecSet(">=2.10").contains(__version__.__version__)
+is_pdm28 = PySpecSet(">=2.8").contains(__version__.__version__)
 
 
 def sources(project: Project, sources: list) -> list[RepositoryConfig]:
@@ -193,8 +194,10 @@ def do_lock(
                     groups=[],
                     strategy={FLAG_STATIC_URLS},
                 )
-            else:
+            elif is_pdm28:
                 data = format_lockfile(project, mapping, dependencies, static_urls=True)
+            else:
+                data = format_lockfile(project, mapping, dependencies)
 
             ui.echo(f"{termui.Emoji.LOCK} Lock successful")
             return data

--- a/pdm-plugin-torch/pdm_plugin_torch/main.py
+++ b/pdm-plugin-torch/pdm_plugin_torch/main.py
@@ -27,6 +27,7 @@ from pdm_plugin_torch.config import Configuration
 
 
 is_pdm210 = PySpecSet(">=2.10").contains(__version__.__version__)
+is_pdm29 = PySpecSet(">=2.9").contains(__version__.__version__)
 is_pdm28 = PySpecSet(">=2.8").contains(__version__.__version__)
 
 
@@ -194,8 +195,13 @@ def do_lock(
                     groups=[],
                     strategy={FLAG_STATIC_URLS},
                 )
+
+            elif is_pdm29:
+                data = format_lockfile(project, mapping, dependencies, static_urls=True)
+
             elif is_pdm28:
                 data = format_lockfile(project, mapping, dependencies, static_urls=True)
+
             else:
                 data = format_lockfile(project, mapping, dependencies)
 
@@ -484,4 +490,8 @@ class TorchCommand(BaseCommand):
 
 
 def torch_plugin(core: Core):
+    if is_pdm28 and not is_pdm29:
+        raise RuntimeError(
+            "pdm 2.8.* is not supported due to not https://github.com/pdm-project/pdm/issues/2151"
+        )
     core.register_command(TorchCommand, "torch")

--- a/pdm-plugin-torch/pdm_plugin_torch/main.py
+++ b/pdm-plugin-torch/pdm_plugin_torch/main.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 import tomlkit
 
-from pdm import termui
+from pdm import __version__, termui
 from pdm._types import RepositoryConfig
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.utils import fetch_hashes, format_lockfile, format_resolution_impossible
@@ -14,7 +14,7 @@ from pdm.core import Core
 from pdm.models.candidates import Candidate
 from pdm.models.repositories import BaseRepository, LockedRepository
 from pdm.models.requirements import Requirement, parse_requirement
-from pdm.models.specifiers import get_specifier
+from pdm.models.specifiers import PySpecSet, get_specifier
 from pdm.project import Project
 from pdm.resolver import resolve
 from pdm.resolver.providers import BaseProvider
@@ -24,6 +24,9 @@ from resolvelib.reporters import BaseReporter
 from resolvelib.resolvers import ResolutionImpossible, ResolutionTooDeep, Resolver
 
 from pdm_plugin_torch.config import Configuration
+
+
+is_pdm210 = PySpecSet(">=2.10").contains(__version__.__version__)
 
 
 def sources(project: Project, sources: list) -> list[RepositoryConfig]:
@@ -180,7 +183,19 @@ def do_lock(
             ui.echo(format_resolution_impossible(err), err=True)
             raise ResolutionImpossible("Unable to find a resolution") from None
         else:
-            data = format_lockfile(project, mapping, dependencies, static_urls=True)
+            if is_pdm210:
+                from pdm.project.lockfile import FLAG_STATIC_URLS
+
+                data = format_lockfile(
+                    project,
+                    mapping,
+                    dependencies,
+                    groups=[],
+                    strategy={FLAG_STATIC_URLS},
+                )
+            else:
+                data = format_lockfile(project, mapping, dependencies, static_urls=True)
+
             ui.echo(f"{termui.Emoji.LOCK} Lock successful")
             return data
 
@@ -249,7 +264,7 @@ def do_sync(
         dry_run=False,
         no_editable=True,
         install_self=False,
-        reinstall=True,
+        reinstall=False,
         only_keep=False,
         fail_fast=True,
     )
@@ -344,7 +359,30 @@ class InstallCommand(BaseCommand):
         lockfile = read_lockfile(project, plugin_config.lockfile)
 
         spec_for_version = lockfile[options.api]
+
         (source, local_version) = resolves[options.api]
+
+        if is_pdm210:
+            from pdm.project.lockfile import FLAG_STATIC_URLS
+
+            class OverrideLockfile:
+                def __init__(self, lockfile):
+                    self._lockfile = lockfile
+
+                @property
+                def strategy(self):
+                    strategies = self._lockfile.strategy
+                    strategies.add(FLAG_STATIC_URLS)
+
+                    return strategies
+
+                def __getattr__(self, name):
+                    return getattr(self._lockfile, name)
+
+            original_lockfile = project.lockfile
+
+            project._lockfile = OverrideLockfile(original_lockfile)
+
         reqs = [
             parse_requirement(f"{req}{local_version}", False)
             for req in plugin_config.dependencies
@@ -363,6 +401,9 @@ class InstallCommand(BaseCommand):
             requirements=reqs,
             lockfile=spec_for_version,
         )
+
+        if is_pdm210:
+            project._lockfile = original_lockfile
 
 
 class LockCommand(BaseCommand):

--- a/pdm-plugin-torch/pdm_plugin_torch/main.py
+++ b/pdm-plugin-torch/pdm_plugin_torch/main.py
@@ -180,7 +180,7 @@ def do_lock(
             ui.echo(format_resolution_impossible(err), err=True)
             raise ResolutionImpossible("Unable to find a resolution") from None
         else:
-            data = format_lockfile(project, mapping, dependencies)
+            data = format_lockfile(project, mapping, dependencies, static_urls=True)
             ui.echo(f"{termui.Emoji.LOCK} Lock successful")
             return data
 
@@ -251,6 +251,7 @@ def do_sync(
         install_self=False,
         reinstall=True,
         only_keep=False,
+        fail_fast=True,
     )
 
     with project.core.ui.logging("install"):


### PR DESCRIPTION
A bit frustrating with the level of hacking we do to piggyback on top of PDM internals. Ending up also removing PDM 2.8 support due to bug https://github.com/pdm-project/pdm/issues/2151, which was only fixed in 2.9. Apart from that all versions seem to work now. 

Will put up a PR with new CI image elsewhere.